### PR TITLE
return result of calling event handler

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1163,9 +1163,9 @@ function render (app, container, opts) {
     keypath.set(handlers, [entityId, path, eventType], function (e) {
       var entity = entities[entityId]
       if (entity) {
-        fn.call(null, e, entity.context, setState(entity))
+        return fn.call(null, e, entity.context, setState(entity))
       } else {
-        fn.call(null, e)
+        return fn.call(null, e)
       }
     })
   }


### PR DESCRIPTION
The event canceling feature introduced in #198 isn't working because the result of the event handler isn't getting returned properly.  Checking fn(event) always returned undefined.
